### PR TITLE
Fixing casing on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ confettysh
 ```sh
 ssh -p2222 localhost
 
-ssh -p2222 localhost -t confetti
-ssh -p2222 localhost -t fireworks
+ssh -p2222 localhost -t Confetti
+ssh -p2222 localhost -t Fireworks
 ```
 
 ## Acknowledgments


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

The casing on the commands in the README.md is wrong.